### PR TITLE
Automatically generate ICS files

### DIFF
--- a/app/clubs/services.py
+++ b/app/clubs/services.py
@@ -1,20 +1,15 @@
+import io
 from datetime import datetime, time, timedelta, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo
 
+import icalendar
+from clubs.models import (Club, ClubMembership, ClubRole, DayChoice, Event,
+                          EventAttendance, RecurringEvent)
+from core.abstracts.services import ServiceBase
 from django.core import exceptions
 from django.db import models
 from django.urls import reverse
-
-from clubs.models import (
-    Club,
-    ClubMembership,
-    ClubRole,
-    DayChoice,
-    Event,
-    EventAttendance,
-    RecurringEvent,
-)
-from core.abstracts.services import ServiceBase
 from users.models import User
 
 
@@ -143,6 +138,60 @@ class ClubService(ServiceBase[Club]):
             location=location,
             description=description,
         )
+    
+    def get_event_calendar(self, event: Event):
+        """Generates an ICS file for an event."""
+        if event.club.id != self.obj.id:
+            raise exceptions.BadRequest(
+                f'Event "{event}" does not belong to club {self.obj}.'
+            )
+        
+        # Initialize calendar
+        cal = icalendar.Calendar()
+        cal.add('PRODID', '-//CSU Portal//UF CSU//EN')
+        cal.add('VERSION', '2.0')
+        cal.add('X-WR-CALNAME', f'{event.name} | {event.club.name}')
+        # Suggest refresh interval of 1hr
+        cal.add('X-PUBLISHED-TTL', 'PT1H')
+        
+        # Configure timezone
+        local_tz = ZoneInfo("America/New_York")
+        
+        # Create event
+        e = icalendar.Event()
+        e.add('SUMMARY', f'{event.name} | {event.club.name}')
+        if event.description is not None:
+            cal.add("X-WR-CALDESC", event.description)
+            e.add('DESCRIPTION', event.description)
+        if event.start_at is not None and event.end_at is not None:
+            local_start_at = event.start_at.replace(tzinfo=local_tz)
+            local_end_at = event.end_at.replace(tzinfo=local_tz)
+            e.add('DTSTART', local_start_at)
+            e.add('DTEND', local_end_at)
+        if event.location is not None:
+            e.add('LOCATION', event.location)
+        
+        # Add recurring event
+        days = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
+        if event.recurring_event is not None:
+            options = {
+                'FREQ': 'WEEKLY',
+                'INTERVAL': 1,
+                'BYDAY': days[event.recurring_event.day]
+            }
+            if event.recurring_event.end_date is not None:
+                until = datetime.combine(event.recurring_event.end_date, datetime.min.time())
+                aware_until = until.replace(tzinfo=local_tz)
+                options['UNTIL'] = aware_until
+
+            e.add('RRULE', options)
+        
+        cal.add_component(e)
+        cal.add_missing_timezones()
+        
+        buffer = io.BytesIO(cal.to_ical())
+        buffer.seek(0)
+        return buffer
 
     def get_registration_url(self):
         """Return link to sign up page."""

--- a/app/clubs/urls.py
+++ b/app/clubs/urls.py
@@ -23,5 +23,10 @@ urlpatterns = [
         ),
         name="join-event-done",
     ),
-    path("polls/", include("clubs.polls.urls")),
+    path(
+        "club/<int:club_id>/event/<int:event_id>/calendar/",
+        views.download_event_calendar,
+        name="get-event-calendar"
+    ),
+    path("polls/", include("clubs.polls.urls"))
 ]

--- a/app/clubs/views.py
+++ b/app/clubs/views.py
@@ -2,13 +2,15 @@
 Club views for API and rendering html pages.
 """
 
-from django.contrib.auth.decorators import login_required
-from django.http import HttpRequest
-from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse
+
+import re
 
 from clubs.models import Club, Event
 from clubs.services import ClubService
+from django.contrib.auth.decorators import login_required
+from django.http import FileResponse, HttpRequest
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 
 @login_required()
@@ -37,6 +39,18 @@ def record_attendance_view(request: HttpRequest, club_id: int, event_id: int):
     ClubService(event.club).record_event_attendance(request.user, event)
 
     return redirect("clubs:join-event-done", club_id=club_id, event_id=event_id)
+
+
+def download_event_calendar(request: HttpRequest, club_id: int, event_id: int):
+    club = get_object_or_404(Club, id=club_id)
+    event = get_object_or_404(Event, id=event_id)
+    
+    club_svc = ClubService(club)
+    file = club_svc.get_event_calendar(event)
+    
+    club_name = re.sub(r'\s+', '_', club.name)
+    event_name = re.sub(r'\s+', '_', event.name)
+    return FileResponse(file, as_attachment=True, filename=f"{club_name}_{event_name}.ics")
 
 
 @login_required()

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,9 @@ django-celery-beat>=2.7.0,<2.8
 boto3>=1.34.0,<1.35.0
 django-storages>=1.14.3,<1.15.0
 
+# ICS files
+icalendar>=6.1.0,<6.2
+
 # Not required for local dev
 sentry-sdk>=2.22.0,<2.23
 psycopg2>=2.9.3,<2.10


### PR DESCRIPTION
### Description

This change adds a route, `club/<int:club_id>/event/<int:event_id>/calendar/`, that automatically generates an ICS file for an event. It supports recurring events and factors in timezones. The generated ICS contains fields that should allow for subscriptions to be created in the future.

[Icalendar](https://github.com/collective/icalendar) was added as a dependency to generate ICS files. 

This change has been successfully tested for Apple and Google calendars.

Contributes to CSU-132.

---

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
