### PR TITLE
Export all future events for a specific club

### DIFF
--- a/app/clubs/services.py
+++ b/app/clubs/services.py
@@ -139,6 +139,29 @@ class ClubService(ServiceBase[Club]):
             description=description,
         )
     
+    def create_calendar(self, name: str):
+        cal = icalendar.Calendar()
+        cal.add('PRODID', '-//CSU Portal//UF CSU//EN')
+        cal.add('VERSION', '2.0')
+        cal.add('X-WR-CALNAME', name)
+        # Suggest refresh interval of 1hr
+        cal.add('X-PUBLISHED-TTL', 'PT1H')
+        return cal
+
+    def create_calendar_event(self, event: Event, tz: ZoneInfo):
+        e = icalendar.Event()
+        e.add('SUMMARY', f'{event.name} | {event.club.name}')
+        if event.description is not None:
+            e.add('DESCRIPTION', event.description)
+        if event.start_at is not None and event.end_at is not None:
+            local_start_at = event.start_at.replace(tzinfo=tz)
+            local_end_at = event.end_at.replace(tzinfo=tz)
+            e.add('DTSTART', local_start_at)
+            e.add('DTEND', local_end_at)
+        if event.location is not None:
+            e.add('LOCATION', event.location)
+        return e
+    
     def get_event_calendar(self, event: Event):
         """Generates an ICS file for an event."""
         if event.club.id != self.obj.id:
@@ -147,33 +170,18 @@ class ClubService(ServiceBase[Club]):
             )
         
         # Initialize calendar
-        cal = icalendar.Calendar()
-        cal.add('PRODID', '-//CSU Portal//UF CSU//EN')
-        cal.add('VERSION', '2.0')
-        cal.add('X-WR-CALNAME', f'{event.name} | {event.club.name}')
-        # Suggest refresh interval of 1hr
-        cal.add('X-PUBLISHED-TTL', 'PT1H')
+        cal = self.create_calendar(f'{event.name} | {event.club.name}')
+        cal.add("X-WR-CALDESC", event.description)
         
         # Configure timezone
         local_tz = ZoneInfo("America/New_York")
         
         # Create event
-        e = icalendar.Event()
-        e.add('SUMMARY', f'{event.name} | {event.club.name}')
-        if event.description is not None:
-            cal.add("X-WR-CALDESC", event.description)
-            e.add('DESCRIPTION', event.description)
-        if event.start_at is not None and event.end_at is not None:
-            local_start_at = event.start_at.replace(tzinfo=local_tz)
-            local_end_at = event.end_at.replace(tzinfo=local_tz)
-            e.add('DTSTART', local_start_at)
-            e.add('DTEND', local_end_at)
-        if event.location is not None:
-            e.add('LOCATION', event.location)
+        e = self.create_calendar_event(event, local_tz)
         
         # Add recurring event
-        days = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
         if event.recurring_event is not None:
+            days = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
             options = {
                 'FREQ': 'WEEKLY',
                 'INTERVAL': 1,
@@ -185,8 +193,32 @@ class ClubService(ServiceBase[Club]):
                 options['UNTIL'] = aware_until
 
             e.add('RRULE', options)
-        
+
         cal.add_component(e)
+        
+        cal.add_missing_timezones()
+        
+        buffer = io.BytesIO(cal.to_ical())
+        buffer.seek(0)
+        return buffer
+    
+    def get_calendar(self):
+        """Generates an ICS file for a club containing all future events."""
+        # Initialize calendar
+        cal = self.create_calendar(self.obj.name)
+        cal.add("X-WR-CALDESC", f"Calendar for {self.obj.name}")
+        
+        # Configure timezone
+        local_tz = ZoneInfo("America/New_York")
+        
+        # Get all events that start later than today
+        now = datetime.now().replace(tzinfo=local_tz)
+        query = Event.objects.filter(start_at__gt=now)
+        
+        for event in query:
+            e = self.create_calendar_event(event, local_tz)
+            cal.add_component(e)
+        
         cal.add_missing_timezones()
         
         buffer = io.BytesIO(cal.to_ical())

--- a/app/clubs/urls.py
+++ b/app/clubs/urls.py
@@ -28,5 +28,10 @@ urlpatterns = [
         views.download_event_calendar,
         name="get-event-calendar"
     ),
+    path(
+        "club/<int:club_id>/calendar/",
+        views.download_club_calendar,
+        name="get-club-calendar"
+    ),
     path("polls/", include("clubs.polls.urls"))
 ]

--- a/app/clubs/views.py
+++ b/app/clubs/views.py
@@ -53,6 +53,15 @@ def download_event_calendar(request: HttpRequest, club_id: int, event_id: int):
     return FileResponse(file, as_attachment=True, filename=f"{club_name}_{event_name}.ics")
 
 
+def download_club_calendar(request: HttpRequest, club_id: int):
+    club = get_object_or_404(Club, id=club_id)
+    
+    club_svc = ClubService(club)
+    file = club_svc.get_calendar()
+    
+    club_name = re.sub(r'\s+', '_', club.name)
+    return FileResponse(file, as_attachment=True, filename=f"{club_name}.ics")
+
 @login_required()
 def available_clubs_view(request: HttpRequest):
     """Display list of clubs to user for them to join."""


### PR DESCRIPTION
### Description

Added a route, `club/<int:club_id>/calendar/`, that automatically generates an ICS file containing all future events for a specific club. Since this is very similar to the existing event calendar generation, I factored some ICS generation code out to prevent duplication.

Closes #84.

---

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
