### PR TITLE
Allow managing user roles within a team using csvs

### DIFF
--- a/app/clubs/models.py
+++ b/app/clubs/models.py
@@ -416,12 +416,11 @@ class TeamMembershipManager(ManagerBase["TeamMembership"]):
 
         membership = self.filter_one(**defaults)
         if not membership:
-            membership = self.create(**{**defaults, **kwargs})
+            membership = self.create(roles=roles, **{**defaults, **kwargs})
         else:
             self.filter(id=membership.id).update(**kwargs)
             membership.refresh_from_db()
-
-        membership.add_roles(*roles)
+            membership.add_roles(*roles)
 
         return membership
 

--- a/app/clubs/tests/test_club_csv.py
+++ b/app/clubs/tests/test_club_csv.py
@@ -44,8 +44,8 @@ class ClubCsvUploadTests(UploadCsvTestsBase):
         }
 
         serializer = self.serializer_class(data=payload, flat=True)
-        self.assertIsNotNone(serializer.instance)
         self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNotNone(serializer.instance)
 
     def test_create_club_from_csv(self):
         """Uploading a csv for a club should create club."""

--- a/app/clubs/tests/test_club_models.py
+++ b/app/clubs/tests/test_club_models.py
@@ -128,8 +128,13 @@ class ClubTeamTests(TestsBase):
 
         team = Team.objects.create(name="Example Team", club=club)
 
-        with self.assertRaises(exceptions.ValidationError):
-            TeamMembership.objects.create(team=team, user=user).save()
+        # with self.assertRaises(exceptions.ValidationError):
+        #     TeamMembership.objects.create(team=team, user=user).save()
+
+        # Changed to add club membership instead
+        TeamMembership.objects.create(team=team, user=user).save()
+        self.assertEqual(user.club_memberships.count(), 1)
+        self.assertEqual(team.memberships.count(), 1)
 
     def test_unique_team_per_club(self):
         """Should not allow duplicate team names per club."""

--- a/app/clubs/tests/test_team_csv.py
+++ b/app/clubs/tests/test_team_csv.py
@@ -1,6 +1,8 @@
-from clubs.models import Team
+from clubs.models import Team, TeamRole
 from clubs.serializers import TeamCsvSerializer
+from clubs.tests.utils import create_test_club
 from querycsv.tests.utils import UploadCsvTestsBase
+from users.tests.utils import create_test_user
 
 
 class TeamCsvTests(UploadCsvTestsBase):
@@ -10,31 +12,39 @@ class TeamCsvTests(UploadCsvTestsBase):
     serializer_class = TeamCsvSerializer
 
     # TODO: Add support for creating nested team roles
-    # def test_upload_team_csv(self):
-    #     """Should be able to upload a csv representing teams."""
+    def test_upload_team_csv(self):
+        """Should be able to upload a csv representing teams."""
 
-    #     club = create_test_club()
-    #     user = create_test_user()
-    #     team = Team.objects.create(name="Test Team 1", club=club)
-    #     TeamRole.objects.create(team=team, name="Test Role 1")
-    #     TeamRole.objects.create(team=team, name="Test Role 2")
+        club = create_test_club()
+        user = create_test_user()
+        team = Team.objects.create(name="Test Team 1", club=club)
+        TeamRole.objects.filter(team=team).delete()
 
-    #     payload = {
-    #         "name": "Test Team 1",
-    #         "club": club.name,
-    #         "memberships[0].user": user.email,
-    #         "memberships[0].roles": "Test Role 1, Test Role 2",
-    #     }
+        TeamRole.objects.create(team=team, name="Test Role 1")
+        TeamRole.objects.create(team=team, name="Test Role 2")
 
-    #     self.assertUploadPayload([payload])
+        # Test with duplicate roles
+        t2 = Team.objects.create(name="Test Team 2", club=club)
+        TeamRole.objects.filter(team=t2).delete()
+        TeamRole.objects.create(team=t2, name="Test Role 1")
 
-    #     self.assertEqual(Team.objects.count(), 1)
-    #     self.assertEqual(club.teams.count(), 1)
+        # Upload CSV
+        payload = {
+            "name": "Test Team 1",
+            "club": club.name,
+            "members[0].user": user.email,
+            "members[0].roles": "Test Role 1, Test Role 2",
+        }
 
-    #     team = Team.objects.first()
-    #     self.assertEqual(team.memberships.count(), 1)
+        self.assertUploadPayload([payload])
 
-    #     member = team.memberships.first()
-    #     self.assertEqual(member.user.email, user.email)
-    #     self.assertEqual(TeamRole.objects.count(), 3)
-    #     self.assertEqual(member.roles.count(), 2)
+        self.assertEqual(Team.objects.count(), 2)
+        self.assertEqual(club.teams.count(), 2)
+
+        team = Team.objects.get(name="Test Team 1")
+        self.assertEqual(team.memberships.count(), 1)
+
+        member = team.memberships.first()
+        self.assertEqual(member.user.email, user.email)
+        self.assertEqual(TeamRole.objects.count(), 3)
+        self.assertEqual(member.roles.count(), 2)

--- a/app/clubs/tests/test_team_csv.py
+++ b/app/clubs/tests/test_team_csv.py
@@ -1,6 +1,7 @@
+from clubs.consts import INITIAL_TEAM_ROLES
 from clubs.models import Team, TeamRole
 from clubs.serializers import TeamCsvSerializer
-from clubs.tests.utils import create_test_club
+from clubs.tests.utils import create_test_club, create_test_team
 from querycsv.tests.utils import UploadCsvTestsBase
 from users.tests.utils import create_test_user
 
@@ -11,21 +12,14 @@ class TeamCsvTests(UploadCsvTestsBase):
     model_class = Team
     serializer_class = TeamCsvSerializer
 
-    # TODO: Add support for creating nested team roles
     def test_upload_team_csv(self):
         """Should be able to upload a csv representing teams."""
 
         club = create_test_club()
         user = create_test_user()
-        team = Team.objects.create(name="Test Team 1", club=club)
-        TeamRole.objects.filter(team=team).delete()
-
-        TeamRole.objects.create(team=team, name="Test Role 1")
-        TeamRole.objects.create(team=team, name="Test Role 2")
 
         # Test with duplicate roles
-        t2 = Team.objects.create(name="Test Team 2", club=club)
-        TeamRole.objects.filter(team=t2).delete()
+        t2 = create_test_team(club=club, name="Test Team 2", clear_roles=True)
         TeamRole.objects.create(team=t2, name="Test Role 1")
 
         # Upload CSV
@@ -40,11 +34,11 @@ class TeamCsvTests(UploadCsvTestsBase):
 
         self.assertEqual(Team.objects.count(), 2)
         self.assertEqual(club.teams.count(), 2)
+        t1 = Team.objects.get(name="Test Team 1")
 
-        team = Team.objects.get(name="Test Team 1")
-        self.assertEqual(team.memberships.count(), 1)
+        self.assertEqual(t1.memberships.count(), 1)
 
-        member = team.memberships.first()
+        member = t1.memberships.first()
         self.assertEqual(member.user.email, user.email)
-        self.assertEqual(TeamRole.objects.count(), 3)
-        self.assertEqual(member.roles.count(), 2)
+        self.assertEqual(TeamRole.objects.count(), 3 + len(INITIAL_TEAM_ROLES))
+        self.assertEqual(member.roles.count(), 2)  # Should not add default role

--- a/app/clubs/tests/utils.py
+++ b/app/clubs/tests/utils.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.urls import reverse
 
-from clubs.models import Club, Team
+from clubs.models import Club, Team, TeamRole
 from lib.faker import fake
 
 CLUB_CREATE_PARAMS = {
@@ -35,12 +35,17 @@ def create_test_clubs(count=5, **kwargs):
     return Club.objects.filter(id__in=ids).all()
 
 
-def create_test_team(club: Club, **kwargs):
+def create_test_team(club: Club, clear_roles=False, **kwargs):
     """Create valid team for unit tests."""
 
     payload = {"name": kwargs.pop("name", f"Team {uuid.uuid4()}"), **kwargs}
 
-    return Team.objects.create(club=club, **payload)
+    team = Team.objects.create(club=club, **payload)
+
+    if clear_roles:
+        TeamRole.objects.filter(team=team).delete()
+
+    return team
 
 
 def join_club_url(club_id: int):

--- a/app/core/abstracts/models.py
+++ b/app/core/abstracts/models.py
@@ -106,7 +106,7 @@ class ManagerBase(models.Manager, Generic[T]):
     def update_or_create(
         self, defaults: MutableMapping[str, Any] | None = None, **kwargs
     ) -> tuple[T, bool]:
-        return super().update_or_create(defaults, **kwargs)
+        return super(ManagerBase, self).update_or_create(defaults, **kwargs)
 
     def all(self) -> models.QuerySet[T]:
         return super().all()

--- a/app/querycsv/serializers.py
+++ b/app/querycsv/serializers.py
@@ -79,6 +79,9 @@ class FlatListField(FlatField):
     sub_key: Optional[str]
     generic_key: str
 
+    list_pattern = r"\[(\d+|n)\]"
+    """Selects all instances of square bracket syntax for lists."""
+
     def __init__(self, key, value, field_types):
         super().__init__(key, value, field_types)
 
@@ -89,7 +92,7 @@ class FlatListField(FlatField):
         return "FlatListField"
 
     def __eq__(self, value):
-        return value == self.key or re.sub(r"\[(\d+|n)\]", "[n]", value) == self.key
+        return value == self.key or re.sub(self.list_pattern, "[n]", value) == self.key
 
     def _set_list_values(self):
         matches = re.match(r"([a-z0-9_-]+)\[(\d+|n)\]\.?(.*)?", self.key)

--- a/app/querycsv/serializers.py
+++ b/app/querycsv/serializers.py
@@ -46,6 +46,8 @@ class FlatField:
 
         if FieldType.LIST in self.field_types and not isinstance(value, list):
             return str_to_list(value)
+        elif isinstance(value, str) and value.isdigit():
+            return int(value)
 
         return value
 
@@ -342,18 +344,48 @@ class CsvModelSerializer(FlatSerializer, ModelSerializerBase):
         # Try to expand out fields before processing
         data = self.flat_to_json(data)
 
-        # Initialize rest of serializer first, needed if data is flat
+        # Then initialize rest of serializer
         super().__init__(data=data, **kwargs)
 
-        # Allow create_or_update functionality
-        try:
-            if instance is None and data is not None and data is not empty:
-                ModelClass = self.model_class
-                search_fields = {}
-                search_query = None
+    def initialize_instance(self, data=empty) -> None:
+        """
+        Set self.instance using data.
 
-                for field in self.unique_fields:
-                    value = data.get(field, None)
+        Allow create_or_update functionality by searching for existing models
+        with the same unique fields. By default, the serializer would fail
+        at the validation stage if an instance exists, but this allows the
+        serialzier to select that instance for update instead.
+        """
+
+        if data is empty or not data or self.instance is not None:
+            return
+
+        try:
+            ModelClass = self.model_class
+            search_query = None
+
+            for field in self.unique_fields:
+                value = data.get(field, None)
+
+                # Remove leading/trailing spaces before processing
+                if value is None or value == "":
+                    continue
+                elif isinstance(value, str):
+                    value = value.strip()
+
+                if search_query is None:
+                    search_query = models.Q(**{field: value})
+                else:
+                    search_query = search_query | models.Q(**{field: value})
+
+            for field_1, field_2 in self.unique_together_fields:
+                values = {
+                    field_1: data.get(field_1, None),
+                    field_2: data.get(field_2, None),
+                }
+
+                for f in [field_1, field_2]:
+                    value = values[f]
 
                     # Remove leading/trailing spaces before processing
                     if value is None or value == "":
@@ -361,23 +393,33 @@ class CsvModelSerializer(FlatSerializer, ModelSerializerBase):
                     elif isinstance(value, str):
                         value = value.strip()
 
-                    search_fields[field] = value
+                    if f in self.related_fields:
+                        values[f] = self.get_fields()[f].to_internal_value(values[f])
 
-                    if search_query is None:
-                        search_query = models.Q(**{field: value})
-                    else:
-                        search_query = search_query | models.Q(**{field: value})
+                query = models.Q(**{field_1: values[field_1]}) & models.Q(
+                    **{field_2: values[field_2]}
+                )
 
-                query = ModelClass.objects.filter(search_query)
-                if query.exists():
-                    instance = query.first()
-            else:
-                self.instance = instance
+                if search_query is None:
+                    search_query = query
+                else:
+                    search_query = search_query | query
+
+            query = ModelClass.objects.filter(search_query)
+            if query.exists():
+                self.instance = query.first()
 
         except Exception:
             pass
 
-        self.instance = instance
+    def to_internal_value(self, data):
+        # Why run initialization here?
+        # This is one of the internal methods that is called first when running
+        # `.is_valid()`, so this fixes any uniqueness issues that would have otherwise
+        # have been raised by the validators.
+
+        self.initialize_instance(data)
+        return super().to_internal_value(data)
 
     def _parse_m2m_value(self, value, field):
         """Parses m2m values for create/update methods."""
@@ -446,6 +488,7 @@ class CsvModelSerializer(FlatSerializer, ModelSerializerBase):
         reverse_many = {}
         reverse_one = {}
 
+        # TODO: Save nested serializers, pass parent if a child serializer
         for field_name, relation_info in info.relations.items():
             if (
                 relation_info.to_many

--- a/app/querycsv/views.py
+++ b/app/querycsv/views.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Type
 
 from django.http import HttpRequest
@@ -8,6 +9,7 @@ from django.template.response import TemplateResponse
 from core.abstracts.serializers import ModelSerializerBase
 from querycsv.forms import CsvHeaderMappingFormSet, CsvUploadForm
 from querycsv.models import QueryCsvUploadJob
+from querycsv.serializers import FlatListField
 from querycsv.services import QueryCsvService
 from querycsv.signals import send_process_csv_job_signal
 
@@ -115,8 +117,11 @@ class QueryCsvViewSet:
 
             for header in job.csv_headers:
                 cleaned_header = header.strip().lower().replace(" ", "_")
-                # if cleaned_header in self.serializer.all_field_names:
-                if cleaned_header in self.service.flat_fields.keys():
+                cleaned_header = re.sub(
+                    FlatListField.list_pattern, "[n]", cleaned_header
+                )
+
+                if cleaned_header in self.service.flat_fields.values():
                     initial_mapping = {
                         "csv_header": header,
                         "object_field": cleaned_header,


### PR DESCRIPTION
### Description

If an admin first creates a club, and creates the necessary users, they can now upload a csv to create a team 
An admin can now upload a csv with this kind of structure:

```json
{
    "name": "Test Team 1",
    "club": "Computing Student Union",
    "members[0].user": "user@example.com",
    "members[0].roles": "Test Role 1, Test Role 2",
    "members[1].user": "user2@example.com",
    "members[1].roles": "Test Role 3",
}
```

And it will automatically:

- Create or update the team
- Assign the user to the team
- Create any roles that don't exist
- Add roles to the user's team membership


Closes #163 

