### PR TITLE
228 event status

### DIFF
--- a/app/events/admin.py
+++ b/app/events/admin.py
@@ -103,6 +103,8 @@ class EventAdmin(ModelAdminBase):
         "location",
         "host_clubs",
         "start_at",
+        "status",
+        "duration",
     )
     ordering = ("-start_at",)
 

--- a/app/events/models.py
+++ b/app/events/models.py
@@ -8,6 +8,7 @@ from typing import ClassVar, Optional
 from django.core import exceptions
 from django.db import models
 from django.utils import timezone
+from utils.formatting import format_timedelta
 from django.utils.timezone import datetime
 from django.utils.translation import gettext_lazy as _
 from django_celery_beat.models import PeriodicTask
@@ -323,6 +324,19 @@ class Event(EventFields):
     @property
     def is_cancelled(self):
         return hasattr(self, "cancellation")
+    
+    @property
+    def status(self):
+        if datetime.now() < self.start_at:
+            return self.status == "SCHEDULED"
+        elif self.start_at <= datetime.now() < self.end_at:
+            return "IN_PROGRESS"
+        else:
+            return "ENDED"
+
+    @property
+    def duration_display(self):
+        return format_timedelta(self.end_at - self.start_at)
 
     # Overrides
     objects: ClassVar[EventManager] = EventManager()

--- a/app/events/models.py
+++ b/app/events/models.py
@@ -327,9 +327,9 @@ class Event(EventFields):
     
     @property
     def status(self):
-        if datetime.now() < self.start_at:
-            return self.status == "SCHEDULED"
-        elif self.start_at <= datetime.now() < self.end_at:
+        if timezone.now() < self.start_at:
+            return "SCHEDULED"
+        elif self.start_at <= timezone.now() < self.end_at:
             return "IN_PROGRESS"
         else:
             return "ENDED"

--- a/app/events/models.py
+++ b/app/events/models.py
@@ -337,8 +337,8 @@ class Event(EventFields):
     @property
     def duration(self):
         return self.end_at - self.start_at
-    
-    @property 
+
+    @property
     def duration_display(self):
         format_timedelta(self.duration)
 

--- a/app/events/models.py
+++ b/app/events/models.py
@@ -335,8 +335,12 @@ class Event(EventFields):
             return "ENDED"
 
     @property
+    def duration(self):
+        return self.end_at - self.start_at
+    
+    @property 
     def duration_display(self):
-        return format_timedelta(self.end_at - self.start_at)
+        format_timedelta(self.duration)
 
     # Overrides
     objects: ClassVar[EventManager] = EventManager()

--- a/app/events/models.py
+++ b/app/events/models.py
@@ -8,7 +8,6 @@ from typing import ClassVar, Optional
 from django.core import exceptions
 from django.db import models
 from django.utils import timezone
-from utils.formatting import format_timedelta
 from django.utils.timezone import datetime
 from django.utils.translation import gettext_lazy as _
 from django_celery_beat.models import PeriodicTask
@@ -18,6 +17,7 @@ from clubs.models import Club, ClubFile, ClubScopedModel
 from core.abstracts.models import ManagerBase, ModelBase, Tag
 from users.models import User
 from utils.dates import get_day_count
+from utils.formatting import format_timedelta
 from utils.models import ArrayChoiceField
 
 
@@ -324,7 +324,7 @@ class Event(EventFields):
     @property
     def is_cancelled(self):
         return hasattr(self, "cancellation")
-    
+
     @property
     def status(self):
         if timezone.now() < self.start_at:

--- a/app/events/serializers.py
+++ b/app/events/serializers.py
@@ -71,7 +71,7 @@ class EventSerializer(ModelSerializerBase):
     is_all_day = serializers.BooleanField(read_only=True)
     attachments = ClubFileNestedSerializer(many=True, required=False)
     status = serializers.CharField(read_only=True)
-    duration_display = serializers.CharField(read_only=True)
+    duration = serializers.CharField(read_only=True)
 
     # attachment_ids = serializers.ListField(
     #    child=serializers.IntegerField(),
@@ -97,7 +97,7 @@ class EventSerializer(ModelSerializerBase):
         #    "created_at",
         #    "updated_at",
         #    "status",
-        #    "duration_display",
+        #    "duration",
         # ]
 
     def validate(self, attrs):

--- a/app/events/serializers.py
+++ b/app/events/serializers.py
@@ -70,6 +70,8 @@ class EventSerializer(ModelSerializerBase):
     tags = EventTagSerializer(many=True, required=False)
     is_all_day = serializers.BooleanField(read_only=True)
     attachments = ClubFileNestedSerializer(many=True, required=False)
+    status = serializers.CharField(read_only=True)
+    duration_display = serializers.CharField(read_only=True)
 
     # attachment_ids = serializers.ListField(
     #    child=serializers.IntegerField(),
@@ -94,6 +96,8 @@ class EventSerializer(ModelSerializerBase):
         #    "all_day",
         #    "created_at",
         #    "updated_at",
+        #    "status",
+        #    "duration_display",
         # ]
 
     def validate(self, attrs):


### PR DESCRIPTION
### Description

Added dynamic "status" property (using @property) to Event model to show if event is SCHEDULED, IN_PROGRESS, or ENDED.

Determined by comparing the current datetime to the start/end datetimes

Added status property to the EventSerializer as a read_only property

Added duration_display that renders duration in a string format like "1h 55m", you can use the existing format_timedelta function in utils/formatting.py

Added duration property to EventSerializer as a read_only property

Added status and duration to EventAdmin

### Type of change

- [X] New feature (non-breaking change which adds functionality)