### PR TITLE
update permissions in poll/field api to allow all authenticated people

### DIFF
--- a/app/polls/admin.py
+++ b/app/polls/admin.py
@@ -118,19 +118,22 @@ class ChoiceInputAdmin(admin.ModelAdmin):
 
     def options_count(self, obj):
         return obj.options.count()
-    
+
+
 class PollQuestionAnswerInlineAdmin(admin.TabularInline):
     """Manage poll question answers in submissions admin."""
 
     model = PollQuestionAnswer
     extra = 0
-    readonly_fields = ('question', 'text_value', 'number_value', 'options_value')
-    exclude = ('error',)
-    
+    readonly_fields = ("question", "text_value", "number_value", "options_value")
+    exclude = ("error",)
+
+
 class PollSubmissionAdmin(admin.ModelAdmin):
     """Manage poll submissions in admin."""
 
     inlines = (PollQuestionAnswerInlineAdmin,)
+
 
 admin.site.register(Poll, PollAdmin)
 admin.site.register(PollQuestion, PollQuestionAdmin)

--- a/app/polls/viewsets.py
+++ b/app/polls/viewsets.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from rest_framework import permissions
 
 from core.abstracts.viewsets import ModelViewSetBase
 from events.models import EventAttendance
@@ -16,14 +17,7 @@ class PollViewset(ModelViewSetBase):
 
     queryset = Poll.objects.all()
     serializer_class = PollSerializer
-
-    def check_permissions(self, request):
-        # FIXME: Configure poll permissions
-        return True
-
-    def check_object_permissions(self, request, obj):
-        # FIXME: Configure poll object permissions
-        return True
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 
 class PollSubmissionViewSet(ModelViewSetBase):
@@ -31,6 +25,7 @@ class PollSubmissionViewSet(ModelViewSetBase):
 
     queryset = PollSubmission.objects.all()
     serializer_class = PollSubmissionSerializer
+    permission_classes = []
 
     def get_queryset(self):
         poll_id = self.kwargs.get("poll_id", None)
@@ -63,6 +58,7 @@ class PollFieldViewSet(ModelViewSetBase):
 
     queryset = PollField.objects.all()
     serializer_class = PollFieldSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_queryset(self):
         poll_id = self.kwargs.get("poll_id", None)


### PR DESCRIPTION
### Description

- Disable explicit allow all permissions in poll api, allow all authenticated users instead (this is just temporary until poll permissions is worked out)
- Format code

---

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
